### PR TITLE
Report error to stderr rather than to stdout

### DIFF
--- a/ttyscheme
+++ b/ttyscheme
@@ -301,7 +301,7 @@ if [ -n "$SELECT" ]; then
 		printf '%b' '\033[2J\033[H'
     fi
 elif [ -n "$1" -o -z "${TTYSCHEME_ARRAY}${TTYSCHEME_ARRAY_SIMPLE}" ]; then
-    echo 'Invalid color scheme. Pass -l for a list of available schemes or -h for further help.'
+    echo 'Invalid color scheme. Pass -l for a list of available schemes or -h for further help.' 1>&2
     exit 1
 fi
 


### PR DESCRIPTION
Thanks for this great collection! :-)

I noticed that error if passed invalid scheme name is currently printed to stdout, which complicated debugging when I integrated it into bigger script. 

This patch redirects that message to stderr